### PR TITLE
Fix for LandEtAl2015/problem3: add missing 0.orig directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ tutorials/fluidSolidInteraction-preCICE/tutorials
 .*~
 *.bak
 *.bak[0-9][0-9]
-*.orig
 *.orig[0-9][0-9]
 \#*\#
 
@@ -77,7 +76,6 @@ SunOS*Gcc*/
 /*.html
 
 # patch residue
-*.orig
 *.rej
 
 # python-compile

--- a/tutorials/LandEtAl2015/problem3/0.orig/D
+++ b/tutorials/LandEtAl2015/problem3/0.orig/D
@@ -1,0 +1,51 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| solids4foam: solid mechanics and fluid-solid interaction simulations        |
+| Version:     v2.0                                                           |
+| Web:         https://solids4foam.github.io                                  |
+| Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
+|              producer and distributor of the OpenFOAM software via          |
+|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              trade marks.                                                   |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volVectorField;
+    object      D;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 1 0 0 0 0 0];
+
+internalField   uniform (0 0 0);
+
+boundaryField
+{
+    fixed
+    {
+        type            fixedDisplacement;
+        value           uniform (0 0 0);
+    }
+    inside
+    {
+        type            solidTraction;
+        traction        uniform ( 0 0 0 );
+        //pressure        uniform 250;
+        pressureSeries
+        {
+            "file|fileName" "$FOAM_CASE/constant/timeVsPressure";
+            outOfBounds clamp;
+        }
+        value           uniform (0 0 0);
+    }
+    outside
+    {
+        type            solidTraction;
+        traction        uniform ( 0 0 0 );
+        pressure        uniform 0;
+        value           uniform (0 0 0);
+    }
+}
+
+// ************************************************************************* //

--- a/tutorials/LandEtAl2015/problem3/0.orig/pointD
+++ b/tutorials/LandEtAl2015/problem3/0.orig/pointD
@@ -1,0 +1,40 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| solids4foam: solid mechanics and fluid-solid interaction simulations        |
+| Version:     v2.0                                                           |
+| Web:         https://solids4foam.github.io                                  |
+| Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
+|              producer and distributor of the OpenFOAM software via          |
+|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              trade marks.                                                   |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       pointVectorField;
+    object      pointD;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 1 0 0 0 0 0];
+
+internalField   uniform (0 0 0);
+
+boundaryField
+{
+    fixed
+    {
+        type            fixedValue;
+        value           uniform (0 0 0);
+    }
+    inside
+    {
+        type            calculated;
+    }
+    outside
+    {
+        type            calculated;
+    }
+}
+
+// ************************************************************************* //

--- a/tutorials/LandEtAl2015/problem3/0.orig/t
+++ b/tutorials/LandEtAl2015/problem3/0.orig/t
@@ -1,0 +1,42 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  2512                                  |
+|   \\  /    A nd           | Website:  www.openfoam.com                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    arch        "LSB;label=32;scalar=64";
+    class       volScalarField;
+    location    "0";
+    object      t;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 0 0 0 0 0 0];
+
+internalField   uniform 0;
+
+boundaryField
+{
+    fixed
+    {
+        type            zeroGradient;
+    }
+    inside
+    {
+        type            fixedValue;
+        value           uniform 0;
+    }
+    outside
+    {
+        type            fixedValue;
+        value           uniform 1;
+    }
+}
+
+
+// ************************************************************************* //


### PR DESCRIPTION
Add the missing `0.orig` directory that should have been part of https://github.com/solids4foam/cardiacFoam/pull/18.

Also, remove `*.orig` from the `.gitignore` file.